### PR TITLE
fix read localized strings issue

### DIFF
--- a/bin/make_sphinx_conf
+++ b/bin/make_sphinx_conf
@@ -38,8 +38,8 @@ while($row = \Osmium\Db\fetch_row($q)) {
 replace('skill_attributes', $skillattribs, $cnf);
 
 replace('sphinx_data', \Osmium\get_ini_setting('sphinx_data'), $cnf);
-replace('sphinx_log', \Osmium\get_ini_setting('sphinx_data'), $cnf);
-replace('sphinx_run', \Osmium\get_ini_setting('sphinx_data'), $cnf);
+replace('sphinx_log', \Osmium\get_ini_setting('sphinx_log'), $cnf);
+replace('sphinx_run', \Osmium\get_ini_setting('sphinx_run'), $cnf);
 
 replace('osmium_root', \Osmium\ROOT, $cnf);
 

--- a/bin/reverence_insert
+++ b/bin/reverence_insert
@@ -70,7 +70,7 @@ def processRows(tablename, columnmap, rowset):
             if row.typeID == 33857 or row.typeID == 33858:
                 continue
 
-        cur.execute(querystring, [ (k(row) if callable(k) else row[k])
+        cur.execute(querystring, [ (k(row) if callable(k) else getattr(row,k) if hasattr(row,k) else row[k])
                                    for k in columnmap.viewvalues() ])
         i += 1
         if i % 25000 == 0:


### PR DESCRIPTION
reverence doesn't read localized string with row[k], see https://github.com/ntt/reverence/blob/master/src/eve/common/script/sys/eveCfg.py