### PR TITLE
fix formatCCPTagSoup issue casued by CEVE translates.

### DIFF
--- a/inc/dom-formatter.php
+++ b/inc/dom-formatter.php
@@ -215,10 +215,10 @@ trait Formatter {
 	/* Format <b>, <u>, <a href=showinfo> and <url=showinfo> tags. */
 	function formatCCPTagSoup($text) {
 		$pieces = preg_split(
-			'%(<a href=showinfo:([1-9][0-9]*)(?:// ?[1-9][0-9]*)?>|</a>|<url=showinfo:([1-9][0-9]*)(?:// ?[1-9][0-9]*)?>|</url>)%',
+			'%(<a href="?showinfo:([1-9][0-9]*)(?:// ?[1-9][0-9]*)?"?>|</a>|<url="?showinfo:([1-9][0-9]*)(?:// ?[1-9][0-9]*)?"?>|</url>)%',
 			$text,
 			-1,
-			PREG_SPLIT_DELIM_CAPTURE
+			PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY
 		);
 
 		$stack = [ [ '', [] ] ];

--- a/inc/dom-formatter.php
+++ b/inc/dom-formatter.php
@@ -215,7 +215,7 @@ trait Formatter {
 	/* Format <b>, <u>, <a href=showinfo> and <url=showinfo> tags. */
 	function formatCCPTagSoup($text) {
 		$pieces = preg_split(
-			'%(<a href="?showinfo:([1-9][0-9]*)(?:// ?[1-9][0-9]*)?"?>|</a>|<url="?showinfo:([1-9][0-9]*)(?:// ?[1-9][0-9]*)?"?>|</url>)%',
+			'%(<a href=(\'|"?)showinfo:([1-9][0-9]*)(?:// ?[1-9][0-9]*)?\2>|</a>|<url=(\'|"?)showinfo:([1-9][0-9]*)(?:// ?[1-9][0-9]*)\4>|</url>)%',
 			$text,
 			-1,
 			PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY
@@ -229,7 +229,7 @@ trait Formatter {
 
 			if($s === '<a h' || $s === '<url') {
 				$typeid = array_shift($pieces);
-
+				if ($typeid === '"' || $typeid === "'") $typeid = array_shift($pieces);
 				++$stackc;
 				$stack[] = [ 'a', [ 'o-rel-href' => '/db/type/'.$typeid ] ];
 				continue;


### PR DESCRIPTION
In Chinese version EVE, some message will cause formatCCPTagSoup throw exception,
eg. nameid 501834
`可以多装配一个<a href="showinfo:3348">作战网络</a>装备`

and some case will return nothing
eg. nameid 501275
`<a href="showinfo:32435">堡垒级巡航导弹</a>和<a href="showinfo:21668">堡垒级鱼雷</a>发射器射速加成`

this will fix it.